### PR TITLE
drawlineの修正と非発見時の対象オブジェクトの変更

### DIFF
--- a/Assets/Resources/Prefab/EnemyUnit.prefab
+++ b/Assets/Resources/Prefab/EnemyUnit.prefab
@@ -2075,6 +2075,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9051c6ede042b1449773748ae0795e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _interpolationDataSource: 0
   VisibleObjects:
   - {fileID: 6714561865675554831}
 --- !u!195 &8795698949838557191
@@ -2182,8 +2183,10 @@ MonoBehaviour:
   - {fileID: 8795698949838557186}
   - {fileID: 1744801743285816924}
   - {fileID: 8795698949838557184}
+  - {fileID: 6824391315215003104}
   - {fileID: 2822435187915350132}
   - {fileID: 8795698949197320146}
+  - {fileID: 8795698949884872788}
   - {fileID: 8795698949617805746}
   SimulationBehaviours: []
 --- !u!1 &1744801743295348193
@@ -3929,6 +3932,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8a903158abf5434f99a349b62098e1e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _interpolationDataSource: 0
 --- !u!120 &8795698949884872789
 LineRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefab/PlayerUnit.prefab
+++ b/Assets/Resources/Prefab/PlayerUnit.prefab
@@ -394,6 +394,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8a903158abf5434f99a349b62098e1e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _interpolationDataSource: 0
 --- !u!120 &406067801650985265
 LineRenderer:
   m_ObjectHideFlags: 0
@@ -2517,8 +2518,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9051c6ede042b1449773748ae0795e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _interpolationDataSource: 0
   VisibleObjects:
-  - {fileID: 590767758866323816}
+  - {fileID: 7070238277223681502}
 --- !u!195 &406067801706209635
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -2599,10 +2601,12 @@ MonoBehaviour:
   - {fileID: 406067801706209638}
   - {fileID: 7459362742995255096}
   - {fileID: 406067801706209636}
+  - {fileID: 1353517780374649495}
   - {fileID: 7987120600909564822}
   - {fileID: 221138280057288734}
   - {fileID: 703712434880474757}
   - {fileID: 111017713333234335}
+  - {fileID: 406067801650985264}
   SimulationBehaviours: []
 --- !u!114 &7987120600909564822
 MonoBehaviour:

--- a/Assets/Scripts/Character/CharacterAttack.cs
+++ b/Assets/Scripts/Character/CharacterAttack.cs
@@ -80,7 +80,7 @@ namespace Unit
                 {
                     if (!isCharacterlive) break;
                     //if(MyCharacterProfile.GetCharacterOwnerType() == OwnerType.Player ) 
-                    MyDrawer.DrawLine(TargetObject.transform.position);                                 //線を引く
+                    if(HasInputAuthority) MyDrawer.DrawLine(TargetObject.transform.position);           //線を引く
                     if (CanAttackState())                                                              
                     {
                         MyCharacterProfile.ChangeCharacterState(CharacterState.Attack);                 //攻撃状態に移行

--- a/Assets/Scripts/Character/CharacterMove.cs
+++ b/Assets/Scripts/Character/CharacterMove.cs
@@ -109,7 +109,7 @@ namespace Unit
                     if (raycastHitList.Any())
                     {
                         var point = raycastHitList.First().point;
-                        var Ydistance = 100 - point.y;
+                        var Ydistance = mainCamera.transform.position.y - point.y;
                         MousePosition.z = Ydistance;
                     }
                     var objPosition = Camera.main.ScreenToWorldPoint(MousePosition);

--- a/Assets/Scripts/Character/CharacterVisible.cs
+++ b/Assets/Scripts/Character/CharacterVisible.cs
@@ -3,34 +3,41 @@ using System.Collections.Generic;
 using UnityEngine;
 using UniRx;
 using System;
+using Fusion;
 
 namespace Unit
 {
-    public class CharacterVisible : MonoBehaviour
+    public class CharacterVisible : NetworkBehaviour
     {
         [SerializeField]
         private GameObject[] VisibleObjects;
         private CharacterStatus MyStatus;
         void Start()
         {
+            RPC_ChangeVisible(false);
+
             MyStatus = GetComponent<CharacterStatus>();
             MyStatus
                 .OniVisibleChanged
                 .Subscribe(value =>
                 {
-                    ChangeVisible(value);
+                    RPC_ChangeVisible(value);
                 }
             );
         }
-
-        //設定したオブジェクトの表示を全て切り替える
-        private void ChangeVisible(bool value)
-        {
-            //Debug.Log($"オブジェクトを表示{value}");
-            foreach (var Objects in VisibleObjects)
+        /// <summary>
+        /// 視覚化の切り替え
+        /// </summary>
+        [Rpc(RpcSources.InputAuthority, RpcTargets.All)]
+        private void RPC_ChangeVisible(bool value)
+        {   
+            if(!HasInputAuthority)
             {
-                Objects.SetActive(value);
+                foreach (var Objects in VisibleObjects)
+                {
+                    Objects.SetActive(value);
+                }
             }
-        }
+        } 
     }
 }

--- a/Assets/Scripts/Character/UI/DrawMoveLine.cs
+++ b/Assets/Scripts/Character/UI/DrawMoveLine.cs
@@ -1,10 +1,11 @@
 using UnityEngine;
 using UnityEngine.AI;
 using UniRx;
+using Fusion;
 
 namespace Unit
 {
-    public class DrawMoveLine : MonoBehaviour
+    public class DrawMoveLine : NetworkBehaviour
     {
         LineRenderer MyLineRenderer;
         CharacterMove MyCharacterMove;
@@ -25,7 +26,7 @@ namespace Unit
             Path = new NavMeshPath();
 
 
-            if (MyProfile.GetCharacterOwnerType() == OwnerType.Player)
+            if (MyProfile.GetCharacterOwnerType() == OwnerType.Player && HasInputAuthority)
             {
                 MyCharacterMove
                     .OnMoveTargetPositionChanged


### PR DESCRIPTION
## 変更点
 - AttackDrawLineを自分のキャラクターしか線を引かないようにした
 - MoveDrawLineを自分のキャラクターしか線を引かないようにした
 - PlayerVIsiableの対象を変更