### PR TITLE
RPCの同期の不具合の修正

### DIFF
--- a/Assets/Scripts/Character/CharacterAttack.cs
+++ b/Assets/Scripts/Character/CharacterAttack.cs
@@ -48,6 +48,7 @@ namespace Unit
                 .Where(x => x != null)
                 .Subscribe(x =>
                 {
+                    if (HasInputAuthority) Debug.Log("攻撃開始：" + Object.InputAuthority);
                     TargetObject = x;
                     StateAction();
                 }
@@ -63,8 +64,6 @@ namespace Unit
             attackRange = MyCharacterProfile.MyattackRange;
             AttaclColleder.radius = MyCharacterProfile.MysearchRange;
             reloadTime = MyCharacterProfile.MyReloadSpeed;
-            Object.AssignInputAuthority(MyCharacterProfile.local);
-            //Debug.Log(name + "：" + Object.InputAuthority.PlayerId);
         }
         
         IEnumerator Attack()
@@ -86,17 +85,17 @@ namespace Unit
                         MyCharacterProfile.ChangeCharacterState(CharacterState.Attack);                 //攻撃状態に移行
 
                         transform.parent.gameObject.transform.LookAt(TargetObject.transform.position);  //攻撃対象に向く
-                        DamageCs.AddDamage(damage);                                                     //敵キャラクターにダメージを与える
+                        if (HasInputAuthority) DamageCs.AddDamage(damage);                                                     //敵キャラクターにダメージを与える
                         yield return ShotEffect();                                                      //攻撃エフェクトを発生させる
                         if (TargetObject == null) break;                                                //攻撃対象がいないとブレイク
-                        if (!AttackRangeChack(TargetObject) || !CanAttackState()) break;  //対象がいない場合はブレイク
+                        if (!AttackRangeCheck(TargetObject) || !CanAttackState()) break;  //対象がいない場合はブレイク
 
                         MyCharacterProfile.ChangeCharacterState(CharacterState.Reload);                 //リロード状態に移行
 
                         yield return new WaitForSeconds(reloadTime);
                     }
                     if (TargetObject == null) break;                                                    //攻撃対象がいないとブレイク
-                    if (!isCharacterlive || !AttackRangeChack(TargetObject) || !CanAttackState()) break;//対象がいない場合はブレイク
+                    if (!isCharacterlive || !AttackRangeCheck(TargetObject) || !CanAttackState()) break;//対象がいない場合はブレイク
 
                 }
                 loseSight = true;
@@ -121,7 +120,7 @@ namespace Unit
             for (int i = 0; i < 3; i++)
             {
                 //Instantiate(BulletPrefab, FirePosition.transform.position, FirePosition.transform.rotation);
-                //if (Object.HasInputAuthority) RPC_ShotBullet();
+                if (Object.HasInputAuthority) RPC_ShotBullet();
                 yield return new WaitForSeconds(0.2f);
             }
         }
@@ -136,7 +135,7 @@ namespace Unit
         /// <summary>
         /// 対象が射程範囲内かどうか
         /// </summary>
-        private bool AttackRangeChack(GameObject TargetGameobject)
+        private bool AttackRangeCheck(GameObject TargetGameobject)
         {
             if (attackRange > ObjectsDistance(TargetGameobject)) return true;
             else return false;

--- a/Assets/Scripts/Character/CharacterMove.cs
+++ b/Assets/Scripts/Character/CharacterMove.cs
@@ -52,15 +52,6 @@ namespace Unit
             mainCamera = Camera.main;
             MyCharacterProfile = GetComponent<CharacterProfile>();
             Agent = GetComponent<NavMeshAgent>();
-            SetInputAuthority();
-        }
-
-        private async void SetInputAuthority()
-        {
-            await Task.Delay(100);
-            
-            Object.AssignInputAuthority(MyCharacterProfile.local);
-            //Debug.Log(name + "：" + Object.InputAuthority.PlayerId);
         }
 
         public void MoveTarget()
@@ -98,7 +89,7 @@ namespace Unit
             if (Object.HasInputAuthority)
             {
                 yield return new WaitUntil(() => IsSelect.Value && (Input.GetKey(KeyCode.Mouse1) || Input.GetKey(KeyCode.Mouse0)));
-                if(Input.GetKey(KeyCode.Q)) MyCharacterProfile.ChangeCharacterState(CharacterState.VigilanceMove);
+                if (Input.GetKey(KeyCode.Q)) MyCharacterProfile.ChangeCharacterState(CharacterState.VigilanceMove);
                 else  MyCharacterProfile.ChangeCharacterState(CharacterState.Move);
     
                 if (Input.GetKey(KeyCode.Mouse1))

--- a/Assets/Scripts/Character/CharacterSearch.cs
+++ b/Assets/Scripts/Character/CharacterSearch.cs
@@ -36,6 +36,7 @@ namespace Unit
                     UnitTargetObject = null;
                     if (CanShotEnemy())
                     {
+                        Debug.Log("敵発見！");
                         MyCharacterProfile.SetTarget(TargetObject);
                     }
                 }).AddTo(this);

--- a/Assets/Scripts/Character/CharacterSpawner.cs
+++ b/Assets/Scripts/Character/CharacterSpawner.cs
@@ -12,8 +12,6 @@ namespace Unit
         private GameObject SpawnPrefab;
         CharacterProfile _profile;
         [SerializeField]
-        private bool isAutoSpawn = false;
-        [SerializeField]
         CharacterData isAutoSpawnCharacterData;
         [SerializeField]
         private GameObject SpawnEffect;
@@ -22,15 +20,6 @@ namespace Unit
         public RoomPlayer RoomPlayer { get; set; }
         
         private CharacterData InstantiateCharacterData;
-        /*
-        void Start()
-        {
-            if (RoomPlayer.Local != null)
-            {
-                _playerRef = RoomPlayer.Local.Object.InputAuthority;
-            }
-        }
-        */
 
         public override void Spawned()
         {
@@ -50,29 +39,51 @@ namespace Unit
         private async void ReSpawn()
         {
             await Task.Delay(3300);
-            var Effect = Instantiate(SpawnEffect, transform.position, Quaternion.identity);
+            var effect = Runner.Spawn(SpawnEffect, transform.position, Quaternion.identity);
             await Task.Delay(1700);
+            Runner.Despawn(effect);
             if (GameLauncher.Runner.GameMode == GameMode.Host)
             {
-                var obj = Runner.Spawn(SpawnPrefab, transform.position, Quaternion.identity, RoomPlayer.Object.InputAuthority);
+                var obj = Runner.Spawn(SpawnPrefab, transform.position, Quaternion.identity, RoomPlayer.Object.InputAuthority, InitCharacterBeforeSpawn);
+                /*
                 _profile = obj.GetComponent<CharacterProfile>();
                 _profile.Init(InstantiateCharacterData);
                 _profile.SetCharacterOwnerType(OwnerType.Player);
                 _profile.local = RoomPlayer.Object.InputAuthority;
-                Debug.Log(RoomPlayer.Object.InputAuthority);
 
                 _profile
                     .OnCharacterStateChanged
-                    .Where(CharacterState => CharacterState == CharacterState.Dead)
-                    .Subscribe(CharacterState =>
+                    .Where(characterState => characterState == CharacterState.Dead)
+                    .Subscribe(characterState =>
                     {
-                        Runner.Despawn(obj);
+                        //Runner.Despawn(obj);
                         Debug.Log("生成" + playerNum);
                         ReSpawnTimer();
                     }
                 ).AddTo(this);
+                 */
             }
         }
+
+        private void InitCharacterBeforeSpawn(NetworkRunner runner, NetworkObject obj)
+        {
+            _profile = obj.GetComponent<CharacterProfile>();
+            _profile.Init(InstantiateCharacterData);
+            _profile.SetCharacterOwnerType(OwnerType.Player);
+            _profile.local = RoomPlayer.Object.InputAuthority;
+
+            _profile
+                .OnCharacterStateChanged
+                .Where(characterState => characterState == CharacterState.Dead)
+                .Subscribe(characterState =>
+                    {
+                        //Runner.Despawn(obj);
+                        Debug.Log("生成" + playerNum);
+                        ReSpawnTimer();
+                    }
+                ).AddTo(this);
+        }
+        
         /// <summary>
         /// リスポーン用のタイマー
         /// </summary>

--- a/Assets/Scripts/Character/CharacterVisible.cs
+++ b/Assets/Scripts/Character/CharacterVisible.cs
@@ -14,14 +14,20 @@ namespace Unit
         private CharacterStatus MyStatus;
         void Start()
         {
-            RPC_ChangeVisible(false);
+            if (HasInputAuthority)
+            {
+                RPC_ChangeVisible(false);
+            }
 
             MyStatus = GetComponent<CharacterStatus>();
             MyStatus
                 .OniVisibleChanged
                 .Subscribe(value =>
                 {
-                    RPC_ChangeVisible(value);
+                    if (HasInputAuthority)
+                    {
+                        RPC_ChangeVisible(value);
+                    }
                 }
             );
         }

--- a/Assets/Scripts/Character/KillMyCharacter.cs
+++ b/Assets/Scripts/Character/KillMyCharacter.cs
@@ -1,7 +1,8 @@
+using Fusion;
 using Unit;
 using UnityEngine;
 
-public class KillMyCharacter : MonoBehaviour
+public class KillMyCharacter : NetworkBehaviour
 {
     private CharacterProfile _target;
     
@@ -14,7 +15,7 @@ public class KillMyCharacter : MonoBehaviour
     {
         if (Input.GetKeyUp(KeyCode.K))
         {
-            if (_target.GetCharacterState() != CharacterState.Dead)
+            if (Object.HasInputAuthority && _target.GetCharacterState() != CharacterState.Dead)
             {
                 _target.AddDamage(999f);
                 Debug.Log("999ダメージ！");

--- a/Assets/Scripts/Character/UI/DesplayProfile.cs
+++ b/Assets/Scripts/Character/UI/DesplayProfile.cs
@@ -39,8 +39,6 @@ namespace Unit
             MyCharacterProfile = GetComponentInParent<CharacterProfile>();
             MyCharacterMove = GetComponentInParent<CharacterMove>();
             InSelectImage.color = Color.clear;
-            Object.AssignInputAuthority(MyCharacterProfile.local);
-            Debug.Log(name + "：" + MyCharacterProfile.local);
 
             //表示される索敵範囲と攻撃範囲の適応
             Vector2 AttackAreaSize = new Vector2(MyCharacterProfile.MyattackRange * 20, MyCharacterProfile.MyattackRange * 20);
@@ -64,18 +62,18 @@ namespace Unit
                     }
                     //HpBar.fillAmount = characterHP / MaxHP;
                     var currentHP = characterHP / MaxHP;
-                    RPC_SetHp(currentHP);
+                    if (HasInputAuthority) RPC_SetHp(currentHP);
                 }
             ).AddTo(this);
 
             //現在状態の同期
             MyCharacterProfile
                 .OnCharacterStateChanged
-                .Subscribe(CharacterState =>
+                .Subscribe(characterState =>
                 {
-                    CharacterStateTMP.transform.LookAt(Camera.transform);
-                    CharacterStateTMP.text = CharacterState.ToString();
-                    //RPC_StateShow(CharacterState);
+                    //CharacterStateTMP.transform.LookAt(Camera.transform);
+                    //CharacterStateTMP.text = CharacterState.ToString();
+                    if (Object.HasInputAuthority) RPC_StateShow(characterState);
                 }
             ).AddTo(this);
 
@@ -98,15 +96,6 @@ namespace Unit
                     }
                 }
             ).AddTo(this);
-            SetInputAuthority();
-        }
-
-        private async void SetInputAuthority()
-        {
-            await Task.Delay(100);
-            
-            Object.AssignInputAuthority(MyCharacterProfile.local);
-            //Debug.Log(name + "：" + Object.InputAuthority.PlayerId);
         }
 
         /// <summary>
@@ -125,7 +114,7 @@ namespace Unit
 
         //ネットワークを介して状態を表すテキストを更新
         [Rpc(RpcSources.InputAuthority, RpcTargets.All)]
-        public void RPC_StateShow(CharacterState state)
+        private void RPC_StateShow(CharacterState state)
         {
             CharacterStateTMP.transform.LookAt(Camera.transform);
             CharacterStateTMP.text = state.ToString();
@@ -133,7 +122,7 @@ namespace Unit
 
         //ネットワークを介して状態を表すテキストを更新
         [Rpc(RpcSources.InputAuthority, RpcTargets.All)]
-        public void RPC_SetHp(float hp)
+        private void RPC_SetHp(float hp)
         {
             HpBar.fillAmount = hp;
         }

--- a/Assets/Scripts/Online/GameLauncher.cs
+++ b/Assets/Scripts/Online/GameLauncher.cs
@@ -10,9 +10,7 @@ namespace Online
     {
         public static GameLauncher Instance { get; private set; }
         public static NetworkRunner Runner;
-        [SerializeField] private HostManager _hostManager;
         [SerializeField] private RoomPlayer _roomPlayer;
-        private GameMode _gameMode;
 
         //private LevelManager _levelManager;
         private NetworkSceneManagerDefault _networkSceneManagerDefault;
@@ -27,7 +25,6 @@ namespace Online
             Instance = this;
             DontDestroyOnLoad(gameObject);
 
-            //_levelManager = GetComponent<LevelManager>();
             _networkSceneManagerDefault = GetComponent<NetworkSceneManagerDefault>();
         }
 
@@ -37,7 +34,6 @@ namespace Online
         public void OnPlayerJoined(NetworkRunner runner, PlayerRef player)
         {
             if (!runner.IsServer) return;
-            if (_gameMode == GameMode.Host) runner.Spawn(_hostManager, Vector3.zero, Quaternion.identity);
             runner.Spawn(_roomPlayer, Vector3.zero, Quaternion.identity, player);
             if (RoomPlayer.Players.Count >= 2) _networkSceneManagerDefault.Runner.SetActiveScene(1);
         }
@@ -81,14 +77,13 @@ namespace Online
         private async void StartGame(GameMode mode)
         {
             if (Runner != null) return;
-            _gameMode = mode;
             
             Runner = gameObject.AddComponent<NetworkRunner>();
             Runner.ProvideInput = true;
 
             await Runner.StartGame(new StartGameArgs()
             {
-                GameMode = GameMode.AutoHostOrClient,
+                GameMode = mode,
                 SessionName = "",
                 SceneManager = _networkSceneManagerDefault,
                 PlayerCount = 2,

--- a/Assets/Scripts/Online/RoomPlayer.cs
+++ b/Assets/Scripts/Online/RoomPlayer.cs
@@ -7,13 +7,6 @@ using UnityEngine;
 
 public class RoomPlayer : NetworkBehaviour
 {
-    public enum EGameState
-    {
-        Lobby,
-        Preparing,
-        GameNow
-    }
-    
     public static readonly List<RoomPlayer> Players = new List<RoomPlayer>();
 
     public static RoomPlayer Local;
@@ -32,8 +25,6 @@ public class RoomPlayer : NetworkBehaviour
         }
         
         Players.Add(this);
-        Debug.Log(Object.InputAuthority);
-        
         DontDestroyOnLoad(gameObject);
     }
 


### PR DESCRIPTION
### 変更点

- RPC_Renderを同期できるように修正
- キャラクターをスポーンさせるまでにCharacterProfileをセットできる機能追加
- RPC_SetHPとRPC_ChangeVisibleのエラーを修正（望んだ動きをしているかどうかは不明）

> RPC_Renderについて新たな問題が発覚。
攻撃のモーションがclient側で同期されない、同タイミングで撃ち合うとclient側が勝つが挙げられる。
先にシーン遷移をやってからまた不具合を修正しに行きます。